### PR TITLE
Fix small typos

### DIFF
--- a/docs/augmented-reality.md
+++ b/docs/augmented-reality.md
@@ -180,7 +180,7 @@ interface R2U {
   <img src="https://scripts-ignition.real2u.com.br/real2u-integration/android-3.png" title="Android 3" width="200"/>
 </p>
 
-## R2U.ar.getlink
+## R2U.ar.getLink
 
 :::tip `mobile` `desktop`
 :::

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   themeConfig: {
     navbar: {
-      title: 'DOCUMENTAÇÂO ',
+      title: 'DOCUMENTAÇÃO ',
       logo: {
         src: 'https://real2u-public-assets.s3.amazonaws.com/images/logo-r2u.png',
       },

--- a/i18n/en/docusaurus-plugin-content-docs/current/augmented-reality.md
+++ b/i18n/en/docusaurus-plugin-content-docs/current/augmented-reality.md
@@ -182,7 +182,7 @@ interface R2U {
   <img src="https://scripts-ignition.real2u.com.br/real2u-integration/android-3.png" title="Android 3" width="200"/>
 </p>
 
-## R2U.ar.getlink
+## R2U.ar.getLink
 
 :::tip `mobile` `desktop`
 :::


### PR DESCRIPTION
Tava vendo a docs hoje e percebi dois typos pequenos

```
getlink --> getLink
```

```
DOCUMENTAÇÂO --> DOCUMENTAÇÃO
```