### PR TITLE
Create minimal flutter docs for v0.0.1

### DIFF
--- a/docs/flutter/analytics.md
+++ b/docs/flutter/analytics.md
@@ -1,0 +1,9 @@
+---
+title: Analytics
+---
+
+## Analytics Setup
+
+<!-- TODO: Add analytics to the Flutter SDK  -->
+
+For more information, please get in touch with our team.

--- a/docs/flutter/augmented-reality.md
+++ b/docs/flutter/augmented-reality.md
@@ -1,0 +1,22 @@
+---
+title: Augmented Reality
+---
+
+After adding the dependency to your app, the methods for creating the Augmented Reality experience will be available through the `R2U` object.
+
+<!-- TODO: Insert gif here -->
+
+## R2U.deviceSupportsAR
+
+:::tip `mobile`
+:::
+
+Returns true if the device supports Augmented Reality. See list of supported devices for [iOS](https://www.apple.com/augmented-reality/) and [Android](https://developers.google.com/ar/devices).
+
+
+## R2U.openAR
+
+:::tip `mobile`
+:::
+
+The `openAR` method displays the given `sku` model inside the AR experience. By default, the `resize` parameter is `false`. Be sure to only display the AR button on supported devices

--- a/docs/flutter/quickstart.md
+++ b/docs/flutter/quickstart.md
@@ -1,0 +1,54 @@
+---
+title: Quick Start
+---
+
+## Integration
+
+The integration of the R2U augmented reality package in Flutter is made by the library [flutter_r2u](https://pub.dev/packages/flutter_r2u), **currently in beta**.
+
+## Installation
+
+1. Add the package `flutter_r2u` to your `pubspec.yaml` under `dependencies`.
+2. Install it with `fluter pub get`
+
+### iOS
+
+1. Add camera access permission request on your [`Info.plist`](https://developer.apple.com/documentation/arkit/verifying_device_support_and_user_permission#2970474)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "___">
+<plist version="1.0">
+<dict>
+  <key>NSCameraUsageDescription</key>
+  <string>Camera used to display product in Augmented Reality</string>
+  ...
+</dict>
+</plist>
+```
+
+2. Install the React Native pod
+
+```
+cd ios
+pod install
+```
+
+### Android
+
+1. Add camera access permission request on your [`AndroidManifest.xml`](https://developers.google.com/ar/develop/java/enable-arcore#ar_optional_apps)
+
+```xml
+<uses-permission android:name="android.permission.CAMERA" />
+
+<application …>
+    ...
+    <!-- "AR Optional" app, contains non-AR features that can be used when
+         "Google Play Services for AR" (ARCore) is not available. -->
+    <meta-data android:name="com.google.ar.core" android:value="optional" />
+</application>
+```
+
+## Getting started
+
+Check out the [sample code](https://pub.dev/packages/flutter_r2u/example) on the package to get you up and running with minimal effort. Be sure to check the rest of the documentation for more detailed information.

--- a/docs/flutter/troubleshooting.md
+++ b/docs/flutter/troubleshooting.md
@@ -1,0 +1,7 @@
+---
+title: Troubleshooting
+---
+
+### (Android) Missing 'package' key attribute on element package at [com.google.ar:core:1.19.0] AndroidManifest.xml
+
+This issue is due to an [old version of gradle](https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html) which does not support ARCore, Google's Augmented Reality SDK for Android. Just update to version 4.1 or follow the indicated process for previous versions.

--- a/docs/flutter/viewer.md
+++ b/docs/flutter/viewer.md
@@ -1,0 +1,16 @@
+---
+title: 3D Viewer
+---
+
+After adding the dependency to your app, the methods for creating a 3D Viewer will be available through the `R2U` object.
+
+<!-- TODO: Insert gif here -->
+
+## R2U.getLink
+
+:::tip `mobile`
+:::
+
+Returns the 3D model viewer URL, to be used in a webview.
+
+<!-- TODO: Create demo and add to package example -->

--- a/i18n/pt/docusaurus-plugin-content-docs/current/flutter/analytics.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/flutter/analytics.md
@@ -1,0 +1,9 @@
+---
+title: Analytics
+---
+
+## Configuração do Analytics
+
+<!-- TODO: Add analytics to the Flutter SDK  -->
+
+Para mais informações, entre em contato com nossa equipe.

--- a/i18n/pt/docusaurus-plugin-content-docs/current/flutter/augmented-reality.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/flutter/augmented-reality.md
@@ -1,0 +1,21 @@
+---
+title: Realidade Aumentada
+---
+
+Após adicionar a dependência ao seu aplicativo, os métodos para criar a experiência de Realidade Aumentada estarão disponíveis através do objeto `R2U`.
+
+<!-- TODO: Insert gif here -->
+
+## R2U.deviceSupportsAR
+
+:::tip `mobile`
+:::
+
+Retorna verdadeiro se o dispositivo suportar Realidade Aumentada. Veja a lista de dispositivos suportados para [iOS](https://www.apple.com/augmented-reality/) e [Android](https://developers.google.com/ar/devices).
+
+## R2U.openAR
+
+:::tip `mobile`
+:::
+
+O método `ar.open` exibe o modelo `sku` fornecido dentro da experiência AR. Por padrão, o parâmetro `resize` é `false`. Certifique-se de exibir o botão RA apenas em dispositivos compatíveis

--- a/i18n/pt/docusaurus-plugin-content-docs/current/flutter/quickstart.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/flutter/quickstart.md
@@ -1,0 +1,54 @@
+---
+title: Início rápido
+---
+
+## Integração
+
+A integração do módulo R2U AR no React Native é feita pelo pacote [flutter_r2u](https://pub.dev/packages/flutter_r2u), **atualmente in beta**.
+
+## Instalação
+
+1. Adicione o pacote `flutter_r2u` ao seu `pubspec.yaml` abaixo de `dependencies`.
+2. Instale com `fluter pub get`
+
+### iOS
+
+1. Adicione a solicitação de permissão de acesso à câmera em seu [`Info.plist`](https://developer.apple.com/documentation/arkit/verifying_device_support_and_user_permission#2970474)
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "___">
+<plist version="1.0">
+<dict>
+  <key>NSCameraUsageDescription</key>
+  <string>Câmera usada para exibir o produto em Realidade Aumentada</string>
+  ...
+</dict>
+</plist>
+```
+
+2. Instale o pod React Native
+
+```
+cd ios
+pod install
+```
+
+### Android
+
+1. Adicione a solicitação de permissão de acesso à câmera em seu [`AndroidManifest.xml`](https://developers.google.com/ar/develop/java/enable-arcore#ar_optional_apps)
+
+```xml
+<uses-permission android:name="android.permission.CAMERA" />
+
+<application …>
+    ...
+    <!-- Aplicativo "AR Optional", contém funcionalidades não-RA que podem ser usadas quando
+         o "Google Play Services for AR" (ARCore) não estiver disponível. -->
+    <meta-data android:name="com.google.ar.core" android:value="optional" />
+</application>
+```
+
+## Início rápido
+
+Confira o [código de exemplo](https://pub.dev/packages/flutter_r2u/example) presente no pacote para começar a trabalhar com o mínimo de esforço. Certifique-se de conferir o restante da documentação para obter informações mais detalhadas.

--- a/i18n/pt/docusaurus-plugin-content-docs/current/flutter/troubleshooting.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/flutter/troubleshooting.md
@@ -1,0 +1,7 @@
+---
+title: Solução de problemas
+---
+
+### (Android) Missing 'package' key attribute on element package at [com.google.ar:core:1.19.0] AndroidManifest.xml
+
+Esse problema é devido a uma [versão antiga do gradle](https://android-developers.googleblog.com/2020/07/preparing-your-build-for-package-visibility-in-android-11.html) que não suporta ARCore, o SDK de Realidade Aumentada do Google para Android. Para resolver, basta atualizar para a versão 4.1 ou seguir o processo indicado para versões anteriores.

--- a/i18n/pt/docusaurus-plugin-content-docs/current/flutter/viewer.md
+++ b/i18n/pt/docusaurus-plugin-content-docs/current/flutter/viewer.md
@@ -1,0 +1,16 @@
+---
+title: Visualizador 3D
+---
+
+Após adicionar a dependência ao seu aplicativo, os métodos de criação de um visualizador 3D estarão disponíveis através do objeto `R2U`.
+
+<!-- TODO: Insert gif here -->
+
+## R2U.getLink
+
+:::tip `mobile`
+:::
+
+Retorna a URL do visualizador do modelo 3D, para ser usado em uma webview.
+
+<!-- TODO: Create demo and add to package example -->

--- a/sidebars.js
+++ b/sidebars.js
@@ -21,6 +21,15 @@ module.exports = {
       ]
     },
     {
+      'Flutter SDK': [
+        'flutter/quickstart',
+        'flutter/augmented-reality',
+        'flutter/viewer',
+        'flutter/analytics',
+        'flutter/troubleshooting'
+      ]
+    },
+    {
       'Swift/Kotlin SDK': [
         'swift-kotlin/quickstart'
       ]


### PR DESCRIPTION
Documentação mínima do Flutter beta
Deve ser melhorada, com gifs e mais exemplos de código, uma vez que tivermos a v0.1